### PR TITLE
Iterator interface for picks, and minor code cleanup. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Sean Leffler <sean@errno.com>"]
 
 [dependencies]
-num = "0.1"
+num-traits = "0.1.36"
 rand = "0.3.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub struct AliasTable<T, F> {
 }
 
 /// An iterator for an alias table.
+#[derive(Clone)]
 pub struct AliasTableIterator<'a, T: 'a, F: 'a, R>
     where R: Rng + Sized
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 //! # Walker-Vose Alias Method
 //! A simple implementation of alias tables using the Walker-Vose method.
 
-extern crate num;
+extern crate num_traits;
 extern crate rand;
 
 use std::fmt;
 use std::iter::{FromIterator, Sum};
 use std::vec::Vec;
 
-use num::{Float, NumCast, One, Zero};
+use num_traits::{Float, NumCast, One, Zero};
 
 use rand::Rng;
 use rand::distributions::range::{Range, SampleRange};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl<T, F> AliasTable<T, F>
     /// Pick a random element from the distribution. Samples from the RNG using `ind_sample` only.
     pub fn pick<'a, R: Rng>(&'a self, rng: &mut R) -> &'a T {
         let idx = self.range.ind_sample(rng);
-        let ref entry = self.table[idx];
+        let entry = &self.table[idx];
         match *entry {
             Aliased { ref threshold, value, alias } => {
                 if &self.float.ind_sample(rng) < threshold {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,10 @@ impl<'a, T: 'a, F, R> Iterator for AliasTableIterator<'a, T, F, R>
     fn next(&mut self) -> Option<Self::Item> {
         Some(self.table.pick(&mut self.rng))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (std::usize::MAX, None)
+    }
 }
 
 impl<'a, T, F> IntoIterator for &'a AliasTable<T, F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,15 +53,15 @@ impl<T, F> AliasTable<T, F>
     pub fn pick<'a, R: Rng>(&'a self, rng: &mut R) -> &'a T {
         let idx = self.range.ind_sample(rng);
         let ref entry = self.table[idx];
-        match entry {
-            &Aliased { ref threshold, value, alias } => {
+        match *entry {
+            Aliased { ref threshold, value, alias } => {
                 if &self.float.ind_sample(rng) < threshold {
                     &self.objs[value]
                 } else {
                     &self.objs[alias]
                 }
             }
-            &Unaliased(idx) => &self.objs[idx],
+            Unaliased(idx) => &self.objs[idx],
         }
     }
 }


### PR DESCRIPTION
This pull requests implements [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) for `&AliasTable`, and introduces `AliasTableIterator` (which implements [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html)).

A few minor code-smells are corrected, too:
 * replaced two multi-line routines with more succinct calls to standard-library functions (namely [`extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html))
 * replaced the `num` dependency with `num_traits`, the only subset of `num` that was used
 * made [clippy](https://github.com/Manishearth/rust-clippy) happy

I use the pick iterator [here](https://github.com/jswrenn/nlptk/blob/c4d89227646f32992573755a9a0d915bb141107c/examples/unigram.rs#L78-L85).